### PR TITLE
python version updated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 ### Dependency Constraints, aka Requirements ###
 [tool.poetry.dependencies]
-python = ">=3.8, <3.13"
+python = ">=3.9, <3.13"
 pyside6= ">=6.6.1"
 
 


### PR DESCRIPTION
The current project's supported Python range (>=3.8,<3.13) is not compatible with some of the required packages Python requirement:
  - sphinx-autobuild requires Python >=3.9, so it will not be satisfied for Python >=3.8,<3.9
Because no versions of sphinx-autobuild match >2024.[10](https://app.readthedocs.org/projects/dmc-view/builds/26405978/#252169526--10).3,<2025.0.0
 and sphinx-autobuild (2024.10.3) requires Python >=3.9, sphinx-autobuild is forbidden.
So, because dmcview depends on sphinx-autobuild (^2024.10.3), version solving failed.

-python range updated to (>=3.9,<3.13) 