### PR TITLE
python version change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 ### Dependency Constraints, aka Requirements ###
 [tool.poetry.dependencies]
-python = ">=3.9, <3.13"
+python = ">=3.10, <3.13"
 pyside6= ">=6.6.1"
 
 


### PR DESCRIPTION
The current project's supported Python range (>=3.9,<3.13) is not compatible with some of the required packages Python requirement:
  - sphinx-autodoc-typehints requires Python >=3.[10](https://app.readthedocs.org/projects/dmc-view/builds/26406774/#252177716--10), so it will not be satisfied for Python >=3.9,<3.10


another python version error.