### PR TITLE
added a requirements in the req.txt file

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 sphinx==8.1.3
 sphinx_rtd_theme== 3.0.1
 sphinx-notfound-page==1.0.4
+sphinxcontrib-spelling==8.0.0


### PR DESCRIPTION
Extension error:
Could not import extension sphinxcontrib.spelling (exception: No module named 'sphinxcontrib.spelling')

added sphinxcontrib.spelling in the requirements.txt file with version 8.0.0