### PR TITLE
changes for theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,11 +89,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only set the theme if we're building docs locally
-    html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
The documentation on readthedocs were built with no error .
However the theme was not applied . 

I removed the whole code but i could remove only the "not" .
if this is not fine i will add the code back and remove the "not".