### PR TITLE
issue 58

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Digital Magnatic Compass View"
 authors = ["Iso", "Alan"]
 maintainers = ["Iso","Alan"]
 license = "AGPL-3.0-only"
-readme = "https://github.com/alanmehio/dmc-view/blob/main/README.rst"
+readme = "README.rst"
 
 homepage = "https://github.com/alanmehio/dmc-view"
 repository = "https://github.com/alanmehio/dmc-view"


### PR DESCRIPTION
readme in pyproject.toml expects the file path (relative to your project directory), not a URL.

this was correct before so i am going to merge it myself.