### PR TITLE
fixed python version/ added to technicaldebt

### DIFF
--- a/TECHNICALDEBT.rst
+++ b/TECHNICALDEBT.rst
@@ -33,3 +33,7 @@ Once this version comes as production version, we need to include it in tox file
 
 .. |done| image::  https://img.shields.io/badge/DONE-green
             :alt: DONE
+
+Known issue
+-----------
+Background of the dmc-view app is being affected by the system's theme (light/dark). It is hard to read the values in dark theme.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 ### Dependency Constraints, aka Requirements ###
 [tool.poetry.dependencies]
-python = ">=3.10, <3.13"
+python = ">=3"
 pyside6= ">=6.6.1"
 
 
@@ -124,36 +124,6 @@ module =["PySide6.*"]
 ignore_errors = true
 #disable_error_code = ["syntax"]
 
-### EXTRAS ###
-[tool.poetry.extras]
-test = [
-    "pytest",
-    "pytest-cov",
-    "pytest-explicit",
-    "pytest-xdist",
-]
-typing = [
-    "mypy",
-    "types-requests",
-    "pytest",
-]
-docs = [
-    "sphinx",
-    "sphinx-autodoc-typehints",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-spelling",
-    "sphinx-inline-tabs",
-    "sphinxcontrib-mermaid",
-]
-docslive = [
-    "sphinx",
-    "sphinx-autodoc-typehints",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-spelling",
-    "sphinx-inline-tabs",
-    "sphinxcontrib-mermaid",
-    "sphinx-autobuild",
-]
 
 [tool.poetry.scripts]
  cli = 'dmcview.cli:main'


### PR DESCRIPTION
Added the darktheme to the know issues in technicaldebt.
changed python version to >=3.
removed "Provides-Extra: docs, docslive, test, typing"