### PR TITLE
issue 110

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 ### Dependency Constraints, aka Requirements ###
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.10"
 pyside6= ">=6.6.1"
 
 


### PR DESCRIPTION
  - sphinx-autodoc-typehints requires Python >=3.10, so it will not be satisfied for Python >=3.9,<3.10

had to change it again to 3.10