### PR TITLE
issue-110

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 ### Dependency Constraints, aka Requirements ###
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.10,<3.13"
 pyside6= ">=6.6.1"
 
 


### PR DESCRIPTION
pyside6 required python version also can not be above 3.13 so also fixed that. 