### PR TITLE
Issue #131

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
       - python --version
       - python -m pip install poetry
       - python -m poetry self add poetry-plugin-export
-      - python -m poetry export -o reqs.txt -E docs --without-hashes
+      - python -m poetry export -o req-docs.txt -E docs
     post_install:
       - python -m pip install -e .
       - python -m pip install pyyaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,7 @@ build:
     pre_install:
       - python --version
       - python -m pip install poetry
+      - python -m poetry self add poetry-plugin-export
       - python -m poetry export -o reqs.txt -E docs --without-hashes
     post_install:
       - python -m pip install -e .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,7 +22,10 @@ build:
       - python -m pip install -e .
       - python -m pip install pyyaml
     pre_build:
-      - python ./scripts/visualize-ga-workflow.py > ./docs/cicd_mermaid.md
+      - |
+        for file in .github/workflows/*.yaml; do
+          python ./scripts/visualize-ga-workflow.py "$file" > "./docs/$(basename "$file" .yaml)_mermaid.md"
+        done
       - python ./scripts/visualize-dockerfile.py > ./docs/dockerfile_mermaid.md
 
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ build:
     pre_install:
       - python --version
       - python -m pip install poetry
-      - python -m poetry export -o req-docs.txt -E docs
+      - python -m poetry export -o reqs.txt -E docs --without-hashes
     post_install:
       - python -m pip install -e .
       - python -m pip install pyyaml

--- a/README.rst
+++ b/README.rst
@@ -6,40 +6,8 @@ Digital Magnatic Compass View
 
 .. start-badges see https://shields.io/badges and collection see https://github.com/inttter/md-badges
 
-.. image:: https://img.shields.io/pypi/v/dmc-view
-    :alt: Production Version
-    :target: https://pypi.org/project/dmc-view/
-
-.. image:: https://img.shields.io/pypi/wheel/dmc-view?color=green&label=wheel
-    :alt: PyPI - Wheel
-    :target: https://pypi.org/project/dmc-view
-
-.. image:: https://img.shields.io/pypi/pyversions/dmc-view?color=blue&label=python&logo=python&logoColor=%23ccccff
-    :alt: Supported Python versions
-    :target: https://pypi.org/project/dmc-view
-
-.. image:: https://readthedocs.org/projects/dmc-view/badge/?version=latest
-    :alt: Read the Docs (version)
-    :target: https://dmc-view.readthedocs.io/en/latest/
-
-
-.. Ruff linter for Fast Python Linting
-
-.. image:: https://img.shields.io/badge/codestyle-ruff-000000.svg
-    :alt: Ruff
-    :target: https://docs.astral.sh/ruff/
-
-  
-.. LICENSE (eg AGPL, MIT)
-
-.. image:: https://img.shields.io/badge/license-GNU_Affero-orange
-    :alt: GNU Affero License
-    :target: https://github.com/Issamricin/dmc-view/blob/master/LICENSE
-
-
-
 | |build| |release_version| |wheel| |supported_versions|
-| |docs| |pylint|
+| |docs| |pylint| |docs_pass|
 | |ruff| |gh-lic| |commits_since_specific_tag_on_main| |commits_since_latest_github_release|
 
 
@@ -124,6 +92,10 @@ License
 
 .. |pylint| image:: https://img.shields.io/badge/linting-pylint-yellowgreen
     :target: https://github.com/pylint-dev/pylint
+
+.. |docs_pass| image:: https://readthedocs.org/projects/dmc-view/badge/?version=latest
+    :alt: Read the Docs (version)
+    :target: https://dmc-view.readthedocs.io/en/latest/
 
 .. PyPI
 

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ License
 
 .. PyPI
 
-.. |release_version| image:: https://img.shields.io/pypi/v/dmcview
+.. |release_version| image:: https://img.shields.io/pypi/v/dmc-view
     :alt: Production Version
     :target: https://pypi.org/project/dmc-view/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ ignore_errors = true
 [tool.poetry.scripts]
  cli = 'dmcview.cli:main'
 
-[tool.poetry.extras] see https://realpython.com/dependency-management-python-poetry/
+[tool.poetry.extras] #see https://realpython.com/dependency-management-python-poetry/
  docs = ["sphinx", "sphinx-rtd-theme", "sphinx-notfound-page", "sphinxcontrib-spelling"]
  
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,8 @@ ignore_errors = true
 [tool.poetry.scripts]
  cli = 'dmcview.cli:main'
 
-#[tool.poetry.extras] see https://realpython.com/dependency-management-python-poetry/
+[tool.poetry.extras] see https://realpython.com/dependency-management-python-poetry/
+ docs = ["sphinx", "sphinx-rtd-theme", "sphinx-notfound-page", "sphinxcontrib-spelling"]
  
 
 ##########


### PR DESCRIPTION
-For pypi label it was a name error, dmcview changed to dmc-view.

-For the doc labels I had to fix the documentation generation error on readthedoc. i fixed some issues in the readthedocs and in the pyproject.toml files. I documented the errors and fixes on a file. I will share it with you.
So now the latest version of readthedocs is back to being working.

-Removed the duplicated labels and re arranged them. 